### PR TITLE
add extra origins compatibility (fixes) https://github.com/MoriyaShiine/extra-origins/issues/124

### DIFF
--- a/src/main/resources/data/extraorigins/tags/items/golden_tools.json
+++ b/src/main/resources/data/extraorigins/tags/items/golden_tools.json
@@ -1,0 +1,14 @@
+{
+    "replace": false,
+    "values": [
+        "medievalweapons:golden_small_axe",
+        "medievalweapons:golden_long_sword",
+        "medievalweapons:golden_dagger",
+        "medievalweapons:golden_francisca",
+        "medievalweapons:golden_big_axe",
+        "medievalweapons:golden_javelin",
+        "medievalweapons:golden_lance",
+        "medievalweapons:golden_healing_staff",
+        "medievalweapons:golden_mace"
+    ]
+}


### PR DESCRIPTION
All this does is add your golden tools to the extra origins tag so Piglins get a bonus out of it. Apologies if I'm missing an item, I didn't look very thoroughly haha.