### PR TITLE
fixed rendering bug

### DIFF
--- a/src/main/java/net/medievalweapons/item/renderer/Big_Axe_Item_Renderer.java
+++ b/src/main/java/net/medievalweapons/item/renderer/Big_Axe_Item_Renderer.java
@@ -29,7 +29,7 @@ public enum Big_Axe_Item_Renderer {
         matrices.push();
 
         model.getTransformation().getTransformation(renderMode).apply(leftHanded, matrices);
-        if (!entity.getOffHandStack().isEmpty()) {
+        if (entity != null && !entity.getOffHandStack().isEmpty()) {
             matrices.multiply(Vec3f.POSITIVE_Z.getDegreesQuaternion(-90.0F));
             matrices.multiply(Vec3f.POSITIVE_Y.getDegreesQuaternion(-90.0F));
             matrices.translate(-0.25D, 0.75D, 0.0D);
@@ -40,7 +40,7 @@ public enum Big_Axe_Item_Renderer {
                 matrices.multiply(Vec3f.POSITIVE_X.getDegreesQuaternion(50.0F));
                 matrices.translate(-0.1D, 1.6D, 0.3D);
                 matrices.multiply(Vec3f.POSITIVE_Z.getDegreesQuaternion(10));
-                if (entity.isBlocking()) {
+                if (entity != null && entity.isBlocking()) {
                     matrices.multiply(Vec3f.POSITIVE_Y.getDegreesQuaternion(-15F));
                 }
             } else {

--- a/src/main/java/net/medievalweapons/item/renderer/Thalleous_Sword_Item_Renderer.java
+++ b/src/main/java/net/medievalweapons/item/renderer/Thalleous_Sword_Item_Renderer.java
@@ -28,9 +28,11 @@ public enum Thalleous_Sword_Item_Renderer {
 
         matrices.push();
         model.getTransformation().getTransformation(renderMode).apply(leftHanded, matrices);
-        if ((renderMode == ModelTransformation.Mode.FIRST_PERSON_LEFT_HAND || renderMode == ModelTransformation.Mode.FIRST_PERSON_RIGHT_HAND) && entity.isBlocking()) {
-            matrices.multiply(Vec3f.POSITIVE_Z.getDegreesQuaternion(30.0F));
-            matrices.multiply(Vec3f.POSITIVE_Y.getDegreesQuaternion(-20.0F));
+        if (entity != null){
+            if ((renderMode == ModelTransformation.Mode.FIRST_PERSON_LEFT_HAND || renderMode == ModelTransformation.Mode.FIRST_PERSON_RIGHT_HAND) && entity.isBlocking()) {
+                matrices.multiply(Vec3f.POSITIVE_Z.getDegreesQuaternion(30.0F));
+                matrices.multiply(Vec3f.POSITIVE_Y.getDegreesQuaternion(-20.0F));
+            }
         }
         matrices.translate(-0.05D, 0.84D, 0.0D);
         matrices.scale(1.0F, -1.0F, -1.0F);


### PR DESCRIPTION
If there is no entity, the client will crash when rendering Big Axe and Thalleous sword. Implementation is minimal conditional check added to where entity is referenced in the renderers.